### PR TITLE
Add scroll-to-top button and scroll restoration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+
 import Navbar from './components/Navbar/Navbar';
 import HeroSection from './components/HeroSection/HeroSection';
 import FeatureCards from './components/FeatureCards/FeatureCards';
@@ -10,11 +11,16 @@ import WhoItsFor from './components/WhoItsFor/WhoItsFor';
 import BecomeASpeaker from './components/BecomeASpeaker/BecomeASpeaker';
 import PlanAhead from './components/PlanAhead/PlanAhead';
 import Engagement from './components/Engagement/Engagement';
-// import CTASection from './components/CTASection/CTASection';
 import Partners from './components/Partners/Partners';
 import Footer from './components/Footer/Footer';
 import TicketSection from './components/Ticket/TicketSection';
+
 import LeaderboardPage from './pages/LeaderboardPage';
+
+import ScrollToTop from "./components/ScrollToTop";
+import ScrollRestoration from "./components/ScrollRestoration";
+
+
 
 function HomePage() {
   return (
@@ -29,16 +35,22 @@ function HomePage() {
       <BecomeASpeaker />
       <PlanAhead />
       <Engagement />
-      
     </>
   );
 }
 
+
+
 function App() {
   return (
     <Router>
+
+      {/* Always open pages from top when route changes */}
+      <ScrollRestoration />
+
       <div className="app">
         <Navbar />
+
         <main>
           <Routes>
             <Route path="/" element={<HomePage />} />
@@ -46,7 +58,12 @@ function App() {
             <Route path="/leaderboard" element={<LeaderboardPage />} />
           </Routes>
         </main>
+
         <Footer />
+
+        {/* Floating scroll button */}
+        <ScrollToTop />
+
       </div>
     </Router>
   );

--- a/src/components/ScrollRestoration.jsx
+++ b/src/components/ScrollRestoration.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollRestoration() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "instant",
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+export default function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  const scrollTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <button
+      onClick={scrollTop}
+      aria-label="Scroll to top"
+      style={{
+        position: "fixed",
+        bottom: "24px",
+        right: "24px",
+        width: "44px",
+        height: "44px",
+        borderRadius: "50%",
+        border: "none",
+        background: "#111",
+        color: "#fff",
+        fontSize: "18px",
+        cursor: "pointer",
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(20px)",
+        transition: "all 0.25s ease",
+        pointerEvents: visible ? "auto" : "none",
+        zIndex: 1000,
+      }}
+    >
+      ↑
+    </button>
+  );
+}


### PR DESCRIPTION
Contributor Name : Tanush Gupta
Issue Number: #14 

This PR improves page navigation on long layouts.

### Added:
- Floating scroll-to-top button that appears after scrolling
- Automatic scroll reset when navigating between routes

### Why:
Currently, users landing on a new page may start mid-scroll depending on previous position.  
The button also helps quickly return to the top on content-heavy pages.

### Implementation:
- Two isolated components: ScrollToTop and ScrollRestoration
- No external dependencies
- No impact on existing logic or layout

Tested locally across all routes.

###Before:
<img width="1883" height="907" alt="image" src="https://github.com/user-attachments/assets/912e6620-d27f-485f-8eab-1493e266bcce" />

###After:
<img width="1879" height="912" alt="image" src="https://github.com/user-attachments/assets/920ca088-f8a7-4f6b-b6fb-c12d572d4b39" />

Happy to adjust styling or threshold if needed.
